### PR TITLE
Add alert id to id field

### DIFF
--- a/Export_Sentinel_Artifacts.ps1
+++ b/Export_Sentinel_Artifacts.ps1
@@ -212,6 +212,7 @@ Function Download-SentinelArtifacts {
             elseif ($ArtifactType.Trim() -eq "Scheduled Analytical Rules") {
                 $ArtifactProvider = "alertRules"
                 $ArtifactKind = "ScheduledAnalyticRules"
+                $alertName = $WorkspaceArtifact.Name
                 $WorkspaceArtifact.id = ""
                 $WorkspaceArtifact.id = "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/$($alertName)')]"
                 $WorkspaceArtifact | Add-Member -NotePropertyName "apiVersion" -NotePropertyValue "2021-09-01-preview" -Force


### PR DESCRIPTION
"id" field is missing rule id.

For example:

Expected Output: `"[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/1aed72d9-70c8-43b5-94e6-eeedc2974478')]"`

Actual output: `"[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/alertRules/)]"`

Small tweak. Imports into sentinel without issues now. 